### PR TITLE
ci(docker): support multi-platform builds in Docker publish workflow

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -25,6 +25,11 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        platform:
+          - linux/amd64
+          - linux/arm64
     permissions:
       contents: read
       packages: write
@@ -33,6 +38,11 @@ jobs:
       id-token: write
 
     steps:
+      - name: Prepare
+        run: |
+          platform=${{ matrix.platform }}
+          echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV          
+      
       - name: Checkout repository
         uses: actions/checkout@v4
 
@@ -87,7 +97,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          platforms: linux/arm64, linux/amd64
+          platforms: ${{ matrix.platform }}
 
       # Sign the resulting Docker image digest except on PRs.
       # This will only write to the public Rekor transparency log when the Docker


### PR DESCRIPTION
- Added a matrix strategy to the Docker publish workflow to enable builds for both linux/amd64 and linux/arm64 platforms.
- Included a preparation step to set the PLATFORM_PAIR environment variable for use in subsequent steps.
- Updated Docker build step to use the matrix.platform variable for improved flexibility in specifying target platforms.