### PR TITLE
fix(config/env): Remove BACKEND_WS_URI, migrate to derive WebSocket U…

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,2 +1,1 @@
 BACKEND_URI='http://localhost:5000'
-BACKEND_WS_URI=ws://<hostname>.local:5000

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This is a [Next.js](https://nextjs.org/)-based application for controlling and m
     - [Building and Deployment](#building-and-deployment)
   - [Configuration](#configuration)
     - [Environment Variables](#environment-variables)
+      - [Details](#details)
   - [API Client](#api-client)
   - [Docker Support](#docker-support)
 
@@ -61,11 +62,9 @@ The application uses the following environment variables:
 | Variable        | Description                                |
 | :-------------- | :----------------------------------------- |
 | BACKEND_URI     | The URI of the backend API                 |
-| BACKEND_WS_URI  | The WebSocket URI for backend interactions |
 
 #### Details
 - **BACKEND_URI**: This variable specifies the URI of the backend API endpoint that the server-side code will interact with. It is generally safe to use `localhost` or `127.0.0.1` if your backend is running on the same server where the Next.js application is deployed.
-- **BACKEND_WS_URI**: This variable specifies the WebSocket URI used by the client-side code. Since clients may connect from different devices, this URI cannot be set to `localhost` or `127.0.0.1`. Instead, you should use a network-accessible address or domain name that clients can access from their own respective networks. e.g., `ws://<hostname>.local:<port>`.
 
 ## API Client
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -59,6 +59,7 @@ export default function Page() {
             <SensorStatistic
               key={"flowmeter-statistic" + String(flowmeter.id)} 
               title={"Flowmeter " + String(flowmeter.id)} 
+              websocketHostname={window.location.hostname}
               sensorRoute={"/v1/sensors/flowmeters/ws/" + String(flowmeter.id)}
             />
           ))}

--- a/app/sensors/ui.tsx
+++ b/app/sensors/ui.tsx
@@ -4,10 +4,11 @@ import { SensorReading } from "../api";
 
 export interface SensorStatisticProps {
     title: string;
+    websocketHostname: string;
     sensorRoute: string;
 }
 
-export const SensorStatistic: React.FC<SensorStatisticProps> = ({ title, sensorRoute }) => {
+export const SensorStatistic: React.FC<SensorStatisticProps> = ({ title, websocketHostname: websocketBase, sensorRoute }) => {
     const [data, setData] = useState<number | undefined>(undefined);
     const [, setSocket] = useState<WebSocket | null>(null);
     const [backendUri, setBackendUri] = useState<string | undefined>(undefined);
@@ -18,8 +19,9 @@ export const SensorStatistic: React.FC<SensorStatisticProps> = ({ title, sensorR
                 const res = await fetch('/api/backend');
                 if (res.ok) {
                     const json = await res.json();
-                    setBackendUri(json.backend_uri);
-                    console.debug("Backend URI:", json.backend_uri);
+                    const backendUri = 'ws://' + websocketBase + ":" + json.backend_port 
+                    setBackendUri(backendUri);
+                    console.debug("Backend URI:", backendUri);
                 }
             } catch (error) {
                 console.error("Error fetching config", error);

--- a/pages/api/backend.ts
+++ b/pages/api/backend.ts
@@ -1,7 +1,9 @@
 import { NextApiRequest, NextApiResponse } from 'next';
 
 const handler = (_req: NextApiRequest, res: NextApiResponse) => {
-  res.status(200).json({ backend_uri: process.env.BACKEND_WS_URI });
+  const backendUri = new URL(process.env.BACKEND_URI || "")
+  const backendPort = backendUri.port
+  res.status(200).json({ backend_port: backendPort });
 };
 
 export default handler;


### PR DESCRIPTION
…RI from BACKEND_URI

* Deprecate BACKEND_WS_URI env variable
* Update README.md to reflect changes in environment variables
* Derive WebSocket hostname from window.location in app/page.tsx
* Modify SensorStatistic component to accept websocketHostname prop
* Adjust backend URI construction in sensors/ui.tsx
* Update /api/backend endpoint to return backend_port instead of backend_uri